### PR TITLE
onChange and initialValueSet

### DIFF
--- a/src/hierarchy-select.js
+++ b/src/hierarchy-select.js
@@ -25,7 +25,7 @@
         },
         initSelect: function() {
             var hiddenFieldValue = this.$hiddenField.val();
-            if (hiddenFieldValue && hiddenFieldValue.length > 0) {
+            if (this.options.initialValueSet && hiddenFieldValue && hiddenFieldValue.length > 0) {
                 this.setValue(hiddenFieldValue);
             } else {
                 var item = this.$menuInner.find('a[data-default-selected]:first');
@@ -299,7 +299,8 @@
         width: 'auto',
         height: '256px',
         hierarchy: true,
-        search: true
+        search: true,
+        initialValueSet: false 
     };
     $.fn.hierarchySelect.Constructor = HierarchySelect;
 

--- a/src/hierarchy-select.js
+++ b/src/hierarchy-select.js
@@ -78,6 +78,7 @@
                 this.$button.html(text);
                 this.$hiddenField.val(value);
                 this.$menu.find('.active').removeClass('active');
+                if (this.options.onChange) this.options.onChange(value);
                 a.addClass('active');
             }
         },

--- a/src/hierarchy-select.js
+++ b/src/hierarchy-select.js
@@ -24,12 +24,17 @@
             this.searchListener();
         },
         initSelect: function() {
-            var item = this.$menuInner.find('a[data-default-selected]:first');
-            if (item.length) {
-                this.setValue(item.data('value'));
+            var hiddenFieldValue = this.$hiddenField.val();
+            if (hiddenFieldValue && hiddenFieldValue.length > 0) {
+                this.setValue(hiddenFieldValue);
             } else {
-                var firstItem = this.$menuInner.find('a:first');
-                this.setValue(firstItem.data('value'));
+                var item = this.$menuInner.find('a[data-default-selected]:first');
+                if (item.length) {
+                    this.setValue(item.data('value'));
+                } else {
+                    var firstItem = this.$menuInner.find('a:first');
+                    this.setValue(firstItem.data('value'));
+                }
             }
         },
         setWidth: function() {


### PR DESCRIPTION
This is a great project that we've been recommending to a few others too!

This PR fills a couple of gaps that we needed for our implementation:

- We needed a callback that is called when an item is selected
- We needed the dropdown to respect the initial value of the hidden field when it initialises

This PR implements two new `options` (which are backwards compatible):

### `onChange`

This is a callback that is called when a selection is made, which includes the value selected.

### `initialValueSet`

This boolean configures the dropdown to use the existing value in the hidden field when it initialises, rather than overwriting it with the default item